### PR TITLE
Fix Product Vision heading format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clippy
 
-# Product Vision
+## Product Vision
 
 For internet users who find themselves having a difficult time organizing and discovering resources on the Web that sparks their interest, we introduce Clippy. Clippy is a social bookmarking service designed for users to explore and manage resources on the Internet. Users can immerse themselves in their own distraction-free space curated by them or explore resources gathered by others in the community. Unlike many other social bookmarking services, such as Pocket, Clippy is currently a free service made available to everyone.
 


### PR DESCRIPTION
"Product Vision" is the same size as the name of the product. Changed it to h2 instead of h1 (sorry, it was driving me crazy).