### PR TITLE
Fix Burndown Chart typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For internet users who find themselves having a difficult time organizing and di
 - [Product Backlog](https://trello.com/b/ui7fei2w/clippy)
 - [Sprint Backlog](https://trello.com/b/ui7fei2w/clippy)
 - [Requirements](artifacts/requirements.md)
-- [Bundown Chart]()
+- [Burndown Chart]()
 - [Velocity Chart]()
 
 ## Task Allocation


### PR DESCRIPTION
There was a typo in our README.md file.